### PR TITLE
Xcode 11 Compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /output/
 /result.json
 /.xcover.yml
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xcover (0.2.0)
+    xcover (0.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -56,4 +56,4 @@ DEPENDENCIES
   xcover!
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Generate a HTML page from Xcode unit test coverage statistics
 
+## Prerequisite
+- [Xcode CLI](https://developer.apple.com/xcode/)
+- [XCParse](https://github.com/ChargePoint/xcparse)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/xcover/config.rb
+++ b/lib/xcover/config.rb
@@ -17,7 +17,11 @@ module Xcover
     end
 
     def derived_data_dir
-      "#{self['derived_data_directory']}/Logs/Test/*.xccovreport"
+      (self['derived_data_directory']).to_s
+    end
+
+    def derived_data_dir_log_test
+      "#{derived_data_dir}/Log/Test"
     end
 
     def output_dir

--- a/lib/xcover/html.rb
+++ b/lib/xcover/html.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 module Xcover
   class Html < Base
     def generate
-      Dir.mkdir(output_dir) unless Dir.exist?(output_dir)
+      FileUtils.mkdir_p(output_dir) unless Dir.exist?(output_dir)
 
       export_report_page
       export_assets

--- a/lib/xcover/version.rb
+++ b/lib/xcover/version.rb
@@ -1,3 +1,3 @@
 module Xcover
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.11.0'.freeze
 end

--- a/spec/lib/xcover/base_spec.rb
+++ b/spec/lib/xcover/base_spec.rb
@@ -39,7 +39,7 @@ describe Xcover::Base do
   describe '#filtered_report_files' do
     context 'directory filtering' do
       it 'ignores all the files in the directory' do
-        ignored_patterns = ['*/List/*']
+        allow(subject).to receive(:ignored_patterns).and_return(['*/List/*'])
         files = [
           {
             'lineCoverage' => 0,
@@ -57,7 +57,7 @@ describe Xcover::Base do
             'name' => 'LocalAttractionTableViewCell.swift'
           }
         ]
-        filtered_files = subject.send('filtered_report_files', files, ignored_patterns)
+        filtered_files = subject.send('filtered_report_files', files)
 
         expect(filtered_files.count).to eq 2
         expect(filtered_files[0]['path']).to eq 'RedPlanet/Detail/LocalAttractionDetailInfoModel.swift'
@@ -67,7 +67,7 @@ describe Xcover::Base do
 
     context 'file extension filtering' do
       it 'ignores all the file with the extension' do
-        ignored_patterns = ['*.json']
+        allow(subject).to receive(:ignored_patterns).and_return(['*.json'])
         files = [
           {
             'lineCoverage' => 0,
@@ -80,7 +80,7 @@ describe Xcover::Base do
             'name' => 'hotel.json'
           }
         ]
-        filtered_files = subject.send('filtered_report_files', files, ignored_patterns)
+        filtered_files = subject.send('filtered_report_files', files)
 
         expect(filtered_files.count).to eq 1
         expect(filtered_files[0]['path']).to eq 'RedPlanet/Detail/LocalAttractionDetailInfoModel.swift'
@@ -89,7 +89,7 @@ describe Xcover::Base do
 
     context 'path and name filtering' do
       it 'ignores the files and directories that is matched with the pattern' do
-        ignored_patterns = ['*Attraction*']
+        allow(subject).to receive(:ignored_patterns).and_return(['*Attraction*'])
         files = [
           {
             'lineCoverage' => 0,
@@ -102,7 +102,7 @@ describe Xcover::Base do
             'name' => 'LocalAttraction.swift'
           }
         ]
-        filtered_files = subject.send('filtered_report_files', files, ignored_patterns)
+        filtered_files = subject.send('filtered_report_files', files)
 
         expect(filtered_files.count).to eq 0
       end

--- a/spec/lib/xcover/config_spec.rb
+++ b/spec/lib/xcover/config_spec.rb
@@ -13,7 +13,15 @@ describe Xcover::Config do
     it 'returns a derived data directory configuration' do
       configuration = described_class.new(subject)
 
-      expect(configuration.derived_data_dir).to eq "#{mocked_configuration(subject)['derived_data_directory']}/Logs/Test/*.xccovreport"
+      expect(configuration.derived_data_dir).to eq mocked_configuration(subject)['derived_data_directory'].to_s
+    end
+  end
+
+  describe '#derived_data_dir_log_test' do
+    it 'returns a derived data directory log test configuration' do
+      configuration = described_class.new(subject)
+
+      expect(configuration.derived_data_dir_log_test).to eq "#{mocked_configuration(subject)['derived_data_directory']}/Log/Test"
     end
   end
 


### PR DESCRIPTION
### What Happened
- I added `xcparse` to generate `xccovreport` from `xcresult`
- I sorted files in a report file by % of line converage. 
- I updated the unit tests.
- I updated gem version to `0.11.0` to sync the version number with `Xcode 11` 

### Insight
- `xcover` was introduced 1 year ago and compatible with `Xcode 9`
- `Xcode 9` and `Xcode 10` export `.xccovreport` in the different directory. 
- `xccovreport` is no longer exported on `Xcode 11` but `xcresult` 
- in order to get the `xccovreport` file, we need `xcparse` from brew to generate it from `xcresult`
